### PR TITLE
Add "environment" to the Trusted Publisher config

### DIFF
--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -154,7 +154,8 @@ module ConfigureTrustedPublisher
         puts "Configuring trusted publisher for #{rubygem_name} in #{File.expand_path(repository)} for " \
              "#{github_repository.join('/')}"
 
-        write_release_action(repository, rubygem_name, environment: add_environment)
+        environment = add_environment
+        write_release_action(repository, rubygem_name, environment:)
 
         gc = GemcutterUtilities.new(
           say: ->(msg) { puts msg },
@@ -179,8 +180,9 @@ module ConfigureTrustedPublisher
           "trusted_publisher" => {
             "repository_name" => name,
             "repository_owner" => owner,
+            "environment" => environment,
             "workflow_filename" => "push_gem.yml"
-          },
+          }.compact,
           "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction"
         }
 


### PR DESCRIPTION
I ran `configure_trusted_publisher` on `net-imap`, because I wanted to stick closer to its "defaults".  But then I noticed that, when it creates the rubygems.org Trusted Publisher, it doesn't configure it with the environment name.

I took a quick peek at [the rubygems.org API](https://github.com/rubygems/rubygems.org/blob/bdc4165bfe747e759fa9ef249573b0dfe5c7203f/app/models/oidc/trusted_publisher/github_action.rb#L40-L42):
```ruby
  def self.permitted_attributes
    %i[repository_owner repository_name workflow_filename environment]
  end
```
then made this change and ran it again, and now it _does_ add the environment.  :)