### PR TITLE
Opt out of persisting credentials

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -29,6 +29,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
         with:

--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -343,6 +343,8 @@ module ConfigureTrustedPublisher
             "          egress-policy: audit",
             nil,
             "      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2",
+            "        with:",
+            "          persist-credentials: false",
             "      - name: Set up Ruby",
             "        uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0",
             "        with:",


### PR DESCRIPTION
`actions/checkout` uses a default value of `true` for `persist-credentials`, which results in credentials being written to the Git config.