### PR TITLE
Prevent overwriting actions files when told not to

### DIFF
--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -363,11 +363,11 @@ module ConfigureTrustedPublisher
         return FileUtils.mkdir_p(File.dirname(action_file)) || true unless File.exist?(action_file)
 
         puts
-        response = ask_yes_or_no(
+        should_overwrite = ask_yes_or_no(
           "#{action_file} already exists, overwrite?",
           default: false
         )
-        return if response == "No"
+        return if should_overwrite == false
 
         true
       end


### PR DESCRIPTION
`#ask_yes_or_no` returns `true`/`false` instead of yes/no. Because of this, we've been overwriting files when the user attempts to opt out.

Fixes: https://github.com/rubygems/configure_trusted_publisher/issues/18

[Command Kit #ask_yes_or_no implementation](https://github.com/postmodern/command_kit.rb/blob/f47aa252a13132f0c2c3ffbae442ff951a79f6ad/lib/command_kit/interactive.rb#L127-L145)