### PR TITLE
Handle `.git` suffix and dots in repo name

### DIFF
--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -240,7 +240,7 @@ module ConfigureTrustedPublisher
         ].each do |uri|
           next unless uri
 
-          if uri =~ %r{github.com[:/](?<owner>[^/]+)/(?<repo>[^/]+)}
+          if uri =~ %r{github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?}
             return Regexp.last_match[:owner], Regexp.last_match[:repo]
           end
         end


### PR DESCRIPTION
The previous Regexp would match `.git` as part of the repo name and cause issues downstream. By preventing the capture of `.git`, we maintain the intended behavior while not requiring users to update their gemspecs.

Fixes: https://github.com/rubygems/configure_trusted_publisher/issues/5