### PR TITLE
Fall back to a pending trusted publisher when the gem does not exist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,6 @@ gem "rubocop-rspec", "~> 2.29"
 
 gem "rspec", "~> 3.0"
 
+gem "webmock", "~> 3.0"
+
 gem "gem-release", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,16 +8,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.2)
+    bigdecimal (4.1.2)
     command_kit (0.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     diff-lcs (1.5.1)
     gem-release (2.2.2)
+    hashdiff (1.2.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    public_suffix (7.0.5)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (12.3.3)
@@ -67,6 +75,10 @@ GEM
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.5.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin-23
@@ -81,6 +93,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.21)
   rubocop-rake (~> 0.6.0)
   rubocop-rspec (~> 2.29)
+  webmock (~> 3.0)
 
 BUNDLED WITH
    2.5.10

--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -230,6 +230,49 @@ module ConfigureTrustedPublisher
         end
       end
 
+      def configure_pending_publisher(gem_client, rubygem_name, config)
+        unless ask_yes_or_no("#{rubygem_name} has not been pushed yet. Configure a pending trusted publisher " \
+                             "so it's ready for the first release?")
+          abort "Skipped configuring a pending trusted publisher for #{rubygem_name}."
+        end
+
+        list = gem_client.rubygems_api_request(
+          :get,
+          "api/v1/oidc/pending_trusted_publishers",
+          scope: "configure_trusted_publishers"
+        ) do |req|
+          req["Accept"] = "application/json"
+          req.add_field "Authorization", gem_client.api_key
+        end
+        unless list.code == "200"
+          abort "Failed to list pending trusted publishers (#{list.code.inspect}):\n#{list.body}"
+        end
+
+        existing = JSON.parse(list.body).select { |pub| pub["rubygem_name"] == rubygem_name }
+        if (dup = existing.find { |pub| publisher_matches?(config, pub) })
+          abort "Pending trusted publisher for #{rubygem_name} already configured for " \
+                "#{dup.dig('trusted_publisher', 'name').inspect}"
+        end
+
+        resp = gem_client.rubygems_api_request(
+          :post,
+          "api/v1/oidc/pending_trusted_publishers",
+          scope: "configure_trusted_publishers"
+        ) do |req|
+          req["Content-Type"] = "application/json"
+          req["Accept"] = "application/json"
+          req.add_field "Authorization", gem_client.api_key
+          req.body = config.merge("rubygem_name" => rubygem_name).to_json
+        end
+
+        if resp.code == "201"
+          return "Successfully configured pending trusted publisher for #{rubygem_name}:\n  " \
+                 "#{gem_client.host}/profile/oidc/pending_trusted_publishers"
+        end
+
+        abort "Failed to configure pending trusted publisher for #{rubygem_name}:\n#{resp.body}"
+      end
+
       def publisher_matches?(config, pub)
         config["trusted_publisher_type"] == pub["trusted_publisher_type"] &&
           config["trusted_publisher"].all? { |k, v| pub["trusted_publisher"][k] == v }

--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -186,49 +186,53 @@ module ConfigureTrustedPublisher
           "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction"
         }
 
-        gc.rubygems_api_request(
+        puts configure_publisher(gc, rubygem_name, config)
+      end
+
+      def configure_publisher(gem_client, rubygem_name, config)
+        resp = gem_client.rubygems_api_request(
           :get,
           "api/v1/gems/#{rubygem_name}/trusted_publishers",
           scope: "configure_trusted_publishers"
         ) do |req|
           req["Accept"] = "application/json"
-          req.add_field "Authorization", gc.api_key
-        end.then do |resp| # rubocop:disable Style/MultilineBlockChain
-          if resp.code != "200"
-            abort "Failed to get trusted publishers for #{rubygem_name} (#{resp.code.inspect}):\n#{resp.body}"
-          end
+          req.add_field "Authorization", gem_client.api_key
+        end
 
+        if resp.code == "200"
           existing = JSON.parse(resp.body)
-          if (e = existing.find do |pub|
-                config["trusted_publisher_type"] == pub["trusted_publisher_type"] &&
-                config["trusted_publisher"].all? do |k, v|
-                  pub["trusted_publisher"][k] == v
-                end
-              end)
-
+          if (e = existing.find { |pub| publisher_matches?(config, pub) })
             abort "Trusted publisher for #{rubygem_name} already configured for " \
                   "#{e.dig('trusted_publisher', 'name').inspect}"
           end
-        end
 
-        resp = gc.rubygems_api_request(
-          :post,
-          "api/v1/gems/#{rubygem_name}/trusted_publishers",
-          scope: "configure_trusted_publishers"
-        ) do |req|
-          req["Content-Type"] = "application/json"
-          req["Accept"] = "application/json"
-          req.add_field "Authorization", gc.api_key
+          create_resp = gem_client.rubygems_api_request(
+            :post,
+            "api/v1/gems/#{rubygem_name}/trusted_publishers",
+            scope: "configure_trusted_publishers"
+          ) do |req|
+            req["Content-Type"] = "application/json"
+            req["Accept"] = "application/json"
+            req.add_field "Authorization", gem_client.api_key
+            req.body = config.to_json
+          end
 
-          req.body = config.to_json
-        end
+          if create_resp.code == "201"
+            return "Successfully configured trusted publisher for #{rubygem_name}:\n  " \
+                   "#{gem_client.host}/gems/#{rubygem_name}/trusted_publishers"
+          end
 
-        if resp.code == "201"
-          puts "Successfully configured trusted publisher for #{rubygem_name}:\n  " \
-               "#{gc.host}/gems/#{rubygem_name}/trusted_publishers"
+          abort "Failed to configure trusted publisher for #{rubygem_name}:\n#{create_resp.body}"
+        elsif resp.code == "404"
+          configure_pending_publisher(gem_client, rubygem_name, config)
         else
-          abort "Failed to configure trusted publisher for #{rubygem_name}:\n#{resp.body}"
+          abort "Failed to get trusted publishers for #{rubygem_name} (#{resp.code.inspect}):\n#{resp.body}"
         end
+      end
+
+      def publisher_matches?(config, pub)
+        config["trusted_publisher_type"] == pub["trusted_publisher_type"] &&
+          config["trusted_publisher"].all? { |k, v| pub["trusted_publisher"][k] == v }
       end
 
       def github_repository

--- a/lib/configure_trusted_publisher/cli.rb
+++ b/lib/configure_trusted_publisher/cli.rb
@@ -274,8 +274,12 @@ module ConfigureTrustedPublisher
       end
 
       def publisher_matches?(config, pub)
-        config["trusted_publisher_type"] == pub["trusted_publisher_type"] &&
-          config["trusted_publisher"].all? { |k, v| pub["trusted_publisher"][k] == v }
+        return false unless config["trusted_publisher_type"] == pub["trusted_publisher_type"]
+
+        pub_attributes = pub["trusted_publisher"]
+        return false unless pub_attributes.is_a?(Hash)
+
+        config["trusted_publisher"].all? { |k, v| pub_attributes[k] == v }
       end
 
       def github_repository

--- a/spec/configure_trusted_publisher/cli/rubygem_spec.rb
+++ b/spec/configure_trusted_publisher/cli/rubygem_spec.rb
@@ -146,4 +146,31 @@ RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
       expect { command.configure_publisher(gc, "brand-new-gem", config) }.to raise_error(SystemExit)
     end
   end
+
+  context "when an existing pending publisher has no nested trusted_publisher" do
+    let(:create_stub) do
+      stub_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 201, body: { id: 1 }.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    before do
+      allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub
+      stub_request(:get, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 200,
+                   body: [{ "rubygem_name" => "brand-new-gem",
+                            "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction",
+                            "trusted_publisher" => nil }].to_json,
+                   headers: { "Content-Type" => "application/json" })
+      create_stub
+    end
+
+    it "does not crash on the malformed entry" do
+      expect { command.configure_publisher(gc, "brand-new-gem", config) }.not_to raise_error
+    end
+
+    it "proceeds to create the pending publisher" do
+      command.configure_publisher(gc, "brand-new-gem", config)
+      expect(create_stub).to have_been_requested
+    end
+  end
 end

--- a/spec/configure_trusted_publisher/cli/rubygem_spec.rb
+++ b/spec/configure_trusted_publisher/cli/rubygem_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "configure_trusted_publisher/cli"
+
+RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
+  subject(:command) { described_class.new }
+
+  let(:gc) do
+    instance_double(ConfigureTrustedPublisher::GemcutterUtilities,
+                    api_key: "key-123",
+                    host: "https://rubygems.org").tap do |dbl|
+      allow(dbl).to receive(:rubygems_api_request) do |method, path, **_kwargs, &block|
+        req = Net::HTTP.const_get(method.to_s.capitalize).new("/#{path}")
+        block&.call(req)
+        Net::HTTP.start("rubygems.org", 443, use_ssl: true) { |http| http.request(req) }
+      end
+    end
+  end
+
+  let(:config) do
+    {
+      "trusted_publisher" => { "repository_owner" => "example", "repository_name" => "brand-new-gem",
+                               "workflow_filename" => "push_gem.yml" },
+      "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction"
+    }
+  end
+
+  before do
+    stub_request(:get, "https://rubygems.org/api/v1/gems/brand-new-gem/trusted_publishers")
+      .to_return(status: 404, body: "This rubygem could not be found.")
+  end
+
+  context "when the gem does not exist and the user accepts" do
+    let(:create_stub) do
+      stub_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .with(body: hash_including("rubygem_name" => "brand-new-gem"))
+        .to_return(status: 201, body: { id: 1 }.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    before do
+      allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub
+      stub_request(:get, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+      create_stub
+    end
+
+    it "posts to the pending publishers endpoint" do
+      command.configure_publisher(gc, "brand-new-gem", config)
+      expect(create_stub).to have_been_requested
+    end
+
+    it "returns a message referencing the pending publishers page" do
+      message = command.configure_publisher(gc, "brand-new-gem", config)
+      expect(message).to include("/profile/oidc/pending_trusted_publishers")
+    end
+  end
+
+  context "when the gem does not exist and the user declines" do
+    before { allow(command).to receive(:ask_yes_or_no).and_return(false) } # rubocop:disable RSpec/SubjectStub
+
+    it "aborts without calling the pending endpoint" do # rubocop:disable RSpec/MultipleExpectations
+      expect { command.configure_publisher(gc, "brand-new-gem", config) }.to raise_error(SystemExit)
+      expect(a_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")).not_to have_been_made
+    end
+  end
+
+  context "when an equivalent pending publisher already exists" do
+    before do
+      allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub
+      stub_request(:get, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 200,
+                   body: [{ "rubygem_name" => "brand-new-gem",
+                            "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction",
+                            "trusted_publisher" => { "repository_owner" => "example",
+                                                     "repository_name" => "brand-new-gem",
+                                                     "workflow_filename" => "push_gem.yml" } }].to_json,
+                   headers: { "Content-Type" => "application/json" })
+    end
+
+    it "aborts on dedup" do
+      expect { command.configure_publisher(gc, "brand-new-gem", config) }.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/configure_trusted_publisher/cli/rubygem_spec.rb
+++ b/spec/configure_trusted_publisher/cli/rubygem_spec.rb
@@ -65,6 +65,35 @@ RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
     end
   end
 
+  context "when the gem already exists" do
+    let(:create_stub) do
+      stub_request(:post, "https://rubygems.org/api/v1/gems/existing-gem/trusted_publishers")
+        .to_return(status: 201, body: { id: 1 }.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    before do
+      stub_request(:get, "https://rubygems.org/api/v1/gems/existing-gem/trusted_publishers")
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+      create_stub
+    end
+
+    it "POSTs to the gem endpoint" do
+      command.configure_publisher(gc, "existing-gem", config)
+      expect(create_stub).to have_been_requested
+    end
+
+    it "returns a message referencing the gem trusted publishers page" do
+      message = command.configure_publisher(gc, "existing-gem", config)
+      expect(message).to include("/gems/existing-gem/trusted_publishers")
+    end
+
+    it "never prompts the user" do
+      allow(command).to receive(:ask_yes_or_no).and_return(nil) # rubocop:disable RSpec/SubjectStub
+      command.configure_publisher(gc, "existing-gem", config)
+      expect(command).not_to have_received(:ask_yes_or_no) # rubocop:disable RSpec/SubjectStub
+    end
+  end
+
   context "when an equivalent pending publisher already exists" do
     before do
       allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub

--- a/spec/configure_trusted_publisher/cli/rubygem_spec.rb
+++ b/spec/configure_trusted_publisher/cli/rubygem_spec.rb
@@ -32,9 +32,17 @@ RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
   end
 
   context "when the gem does not exist and the user accepts" do
+    let(:expected_body) do
+      {
+        "rubygem_name" => "brand-new-gem",
+        "trusted_publisher_type" => "OIDC::TrustedPublisher::GitHubAction",
+        "trusted_publisher" => { "repository_owner" => "example", "repository_name" => "brand-new-gem",
+                                 "workflow_filename" => "push_gem.yml" }
+      }
+    end
     let(:create_stub) do
       stub_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
-        .with(body: hash_including("rubygem_name" => "brand-new-gem"))
+        .with(body: expected_body)
         .to_return(status: 201, body: { id: 1 }.to_json, headers: { "Content-Type" => "application/json" })
     end
 
@@ -45,7 +53,7 @@ RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
       create_stub
     end
 
-    it "posts to the pending publishers endpoint" do
+    it "posts the full config plus rubygem_name to the pending publishers endpoint" do
       command.configure_publisher(gc, "brand-new-gem", config)
       expect(create_stub).to have_been_requested
     end
@@ -53,6 +61,33 @@ RSpec.describe ConfigureTrustedPublisher::CLI::Rubygem do
     it "returns a message referencing the pending publishers page" do
       message = command.configure_publisher(gc, "brand-new-gem", config)
       expect(message).to include("/profile/oidc/pending_trusted_publishers")
+    end
+  end
+
+  context "when the gem does not exist, the user accepts, but the pending POST fails" do
+    before do
+      allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub
+      stub_request(:get, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+      stub_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 422, body: "Validation failed.")
+    end
+
+    it "aborts and does not return a success message" do
+      expect { command.configure_publisher(gc, "brand-new-gem", config) }.to raise_error(SystemExit)
+    end
+  end
+
+  context "when the gem does not exist, the user accepts, but listing pending publishers fails" do
+    before do
+      allow(command).to receive(:ask_yes_or_no).and_return(true) # rubocop:disable RSpec/SubjectStub
+      stub_request(:get, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")
+        .to_return(status: 500, body: "Internal Server Error")
+    end
+
+    it "aborts without posting to the pending endpoint" do # rubocop:disable RSpec/MultipleExpectations
+      expect { command.configure_publisher(gc, "brand-new-gem", config) }.to raise_error(SystemExit)
+      expect(a_request(:post, "https://rubygems.org/api/v1/oidc/pending_trusted_publishers")).not_to have_been_made
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require "bundler/setup"
 require "configure_trusted_publisher"
+require "webmock/rspec"
+WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
When configuring a trusted publisher for a gem that has not been pushed yet, the gem endpoint (`api/v1/gems/:name/trusted_publishers`) returns 404 and the CLI aborts. This change lets the CLI instead register a **pending** trusted publisher so keyless publishing is ready for the first release.

## Behavior

- On a 404 from the gem endpoint, prompt the user: configure a pending trusted publisher?
  - **Decline** → abort.
  - **Accept** → `GET`/`POST api/v1/oidc/pending_trusted_publishers`, deduping the pending list by `rubygem_name`, then POSTing the config with `rubygem_name` added. Success points at the pending publishers page.
- The existing-gem (200) path is unchanged.

## Implementation

- Extracted the GET-dedup-POST flow out of `run` into a testable `configure_publisher` (+ `publisher_matches?`), then added `configure_pending_publisher` for the 404 fallback.
- `publisher_matches?` is resilient to a list entry whose nested `trusted_publisher` is missing or malformed (returns no-match instead of raising).
- Added WebMock and specs covering: 404 accept → pending POST with the full body, decline → no POST, dedup match → abort, non-200 list / non-201 POST → abort, malformed entry → no crash, and the existing-gem 200 path as a regression guard.

## Depends on

The new `api/v1/oidc/pending_trusted_publishers` endpoint added in rubygems/rubygems.org#6637. That PR also makes the pending index serialize a nested `trusted_publisher`, which this CLI's dedup consumes.